### PR TITLE
Handle "Removed ..." lines

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,7 @@ impl<'a> AddInfo<'a> {
 pub enum Entry<'a> {
     Updated(&'a str, UpdateInfo<'a>),
     Added(AddInfo<'a>),
+    Removed(&'a str),
 }
 
 impl<'a> Entry<'a> {
@@ -193,6 +194,9 @@ impl<'a> Entry<'a> {
                     dated_ref.date
                 ),
             },
+            Entry::Removed(name) => {
+                format!(" - Removed input `{name}`")
+            }
         }
     }
 }
@@ -222,8 +226,16 @@ fn parse_added(input: &str) -> IResult<&str, Entry<'_>> {
     Ok((input, Entry::Added(info)))
 }
 
+fn parse_removed(input: &str) -> IResult<&str, Entry<'_>> {
+    let (input, _) = tag("• Removed input '")(input)?;
+    let (input, package) = take_until("'")(input)?;
+    let (input, _) = tag("'")(input)?;
+    let (input, _) = line_ending(input)?;
+    Ok((input, Entry::Removed(package)))
+}
+
 pub fn parse_entry(input: &str) -> IResult<&str, Entry<'_>> {
-    alt((parse_updated, parse_added)).parse(input)
+    alt((parse_updated, parse_added, parse_removed)).parse(input)
 }
 
 #[cfg(test)]
@@ -277,6 +289,7 @@ mod tests {
   → 'github:iff/nihilistic-nvim/9e091eb0f9ccee2ab2711b2226fec9c6af15fb6a' (2025-10-07)
 • Added input 'ltstatus/flake-utils':
     'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' (2024-11-13)
+• Removed input 'llm-agents/bun2nix/import-tree'
 • Updated input 'nixpkgs':
     'github:nixos/nixpkgs/dc704e6102e76aad573f63b74c742cd96f8f1e6c' (2025-10-02)
   → 'github:nixos/nixpkgs/2dad7af78a183b6c486702c18af8a9544f298377' (2025-10-09)
@@ -292,7 +305,7 @@ mod tests {
             .parse(remaining)
             .expect("Failed to parse entries");
 
-        assert_eq!(entries.len(), 7);
+        assert_eq!(entries.len(), 8);
 
         match &entries[0] {
             Entry::Updated(name, info) => {
@@ -326,6 +339,13 @@ mod tests {
                 assert_eq!(info.date, "2024-11-13");
             }
             _ => panic!("Expected Added entry with New"),
+        }
+
+        match &entries[4] {
+            Entry::Removed(name) => {
+                assert_eq!(*name, "llm-agents/bun2nix/import-tree");
+            }
+            _ => panic!("Expected Removed entry"),
         }
 
         match &entries.last().unwrap() {


### PR DESCRIPTION
`nix flake update` can generate lines in the form:

```
• Removed input '<name>'
```

This PR adds support for parsing those. Without this change, parsing fails on the first unrecognized line. That may cut off the summary and give an incomplete picture of the flake update:

In my case, I had the following output from `nix flake update`:

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/e09259dd2e147d35ef889784b51e89b0a10ffe15?narHash=sha256-AF0cby9Xuijr5qaFpYKbm1mExV956Hk233bel6QxpFw%3D' (2026-04-23)
  → 'github:nix-community/home-manager/9cb587ade2aa1b4a7257f0238d41072690b0ca4f?narHash=sha256-egYNbRrkn%2B6SwTHinhdb6WUfzzdC3nXfCRqS321VylY%3D' (2026-05-01)
• Updated input 'llm-agents':
    'github:numtide/llm-agents.nix/6b4673fddbbe1f2656b3fa8d2a32666570aafbfa?narHash=sha256-tBvsFPJy0/2gocc6QGYFXJF44TvJ8PC726NsdTpFJ44%3D' (2026-04-25)
  → 'github:numtide/llm-agents.nix/a2cd1d9eda4a84d713153f718c8583e1a4c89983?narHash=sha256-AmiRSWOXXJyB/rBRZZKwJWRfM5O%2BxGO4Pe8V%2BXFd6Kc%3D' (2026-05-02)
• Updated input 'llm-agents/bun2nix':
    'github:nix-community/bun2nix/6ef9f144616eedea90b364bb408ef2e1de7b310a?narHash=sha256-5gYQNEs0/vDkHhg63aHS5g0IwG/8HNvU1Vr00cElofk%3D' (2026-04-14)
  → 'github:nix-community/bun2nix/e659e1cc4b8e1b21d0aa85f1c481f9db61ecfa98?narHash=sha256-1xW7cRZNsFNPQD%2BcE0fwnLVStnDth0HSoASEIFeT7uI%3D' (2026-04-28)
• Removed input 'llm-agents/bun2nix/import-tree'
• Updated input 'llm-agents/flake-parts':
    'github:hercules-ci/flake-parts/3107b77cd68437b9a76194f0f7f9c55f2329ca5b?narHash=sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA%3D' (2026-04-01)
  → 'github:hercules-ci/flake-parts/5250617bffd85403b14dbf43c3870e7f255d2c16?narHash=sha256-EPIFsulyon7Z1vLQq5Fk64GR8L7cQsT%2BIPhcsukVbgk%3D' (2026-05-01)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/b12141ef619e0a9c1c84dc8c684040326f27cdcc?narHash=sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24%3D' (2026-04-18)
  → 'github:nixos/nixpkgs/15f4ee454b1dce334612fa6843b3e05cf546efab?narHash=sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM%2BZ4%3D' (2026-04-30)
• Updated input 'osh-oxy':
    'github:iff/osh-oxy/b38dc57be46b3e3d770dcd9a6832213c3c8bf347?narHash=sha256-KxAVXDVZ2ddGmUgaPtHB%2BA9h/Sbq9rznYS/X/%2BgZZyw%3D' (2026-04-16)
  → 'github:iff/osh-oxy/eeaef76df2c680681809b40880c004938bd18324?narHash=sha256-W29cG5DJUi7SDUwAedFx9tHMUL3p7/9YOYYHTRCEiU0%3D' (2026-04-26)
```

but only this summary:

 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`e09259dd` ➡️ `9cb587ad`](https://github.com/nix-community/home-manager/compare/e09259dd2e147d35ef889784b51e89b0a10ffe15...9cb587ade2aa1b4a7257f0238d41072690b0ca4f) <sub>(2026-04-23 to 2026-05-01)<sub/>
 - Updated input [`llm-agents`](https://github.com/numtide/llm-agents.nix): [`6b4673fd` ➡️ `a2cd1d9e`](https://github.com/numtide/llm-agents.nix/compare/6b4673fddbbe1f2656b3fa8d2a32666570aafbfa...a2cd1d9eda4a84d713153f718c8583e1a4c89983) <sub>(2026-04-25 to 2026-05-02)<sub/>
 - Updated input [`llm-agents/bun2nix`](https://github.com/nix-community/bun2nix): [`6ef9f144` ➡️ `e659e1cc`](https://github.com/nix-community/bun2nix/compare/6ef9f144616eedea90b364bb408ef2e1de7b310a...e659e1cc4b8e1b21d0aa85f1c481f9db61ecfa98) <sub>(2026-04-14 to 2026-04-28)<sub/>

Note that everything past the "Removed ..." line is missing.